### PR TITLE
Assert is_rainy == false to match value that was inserted

### DIFF
--- a/examples/prepared_statements.rs
+++ b/examples/prepared_statements.rs
@@ -46,7 +46,7 @@ pub fn main() {
 
     let day: Vertex<Day> = x[0].get(0);
     assert_eq!(day.properties().month, 2);
-    assert!(day.properties().is_rainy);
+    assert_eq!(day.properties().is_rainy, false);
     assert_eq!(day.properties().name, "Some day");
 
     client.drop_graph("prepared_statementes_sync").unwrap();

--- a/examples/prepared_statements_async.rs
+++ b/examples/prepared_statements_async.rs
@@ -50,7 +50,7 @@ pub async fn main() {
 
     let day: Vertex<Day> = x[0].get(0);
     assert_eq!(day.properties().month, 2);
-    assert!(day.properties().is_rainy);
+    assert_eq!(day.properties().is_rainy, false);
     assert_eq!(day.properties().name, "Some day");
 
     client.drop_graph("prepared_statements").await.unwrap();


### PR DESCRIPTION
My deepest apologies, if I'm missing something here (likely!), but I ran into test failures locally, so this is my attempt to fix them.

This reverts a change that was introduced in https://github.com/Dzordzu/rust-apache-age/commit/572c3c3eefe442ce4a808e32f74b1222d54a7c9d for the example assertions on `day.properties().is_rainy`, and fixes the tests for me.

I believe this to be the correct behavior, since the `day` object has `is_rainy: false` when passed in the `CREATE` statement, when reading the `day` back out from the database.