### PR TITLE
feat: don't require `&mut self` for the async client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/.idea/

--- a/examples/prepared_statements_async.rs
+++ b/examples/prepared_statements_async.rs
@@ -13,7 +13,7 @@ unsafe impl<'a> Sync for Day<'a> {}
 
 #[tokio::main]
 pub async fn main() {
-    let (mut client, _) = Client::connect_age(
+    let (client, _) = Client::connect_age(
         "host=localhost user=postgres password=passwd port=8081",
         NoTls,
     )

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -29,7 +29,7 @@ pub trait AgeClient {
     ///
     /// **IMPORTANT**: At least one object has to be created with a certain label
     async fn constraint(
-        &mut self,
+        &self,
         graph: &str,
         label: &str,
         name: &str,
@@ -40,7 +40,7 @@ pub trait AgeClient {
     ///
     /// **IMPORTANT**: At least one object has to be created with a certain label
     async fn unique_index(
-        &mut self,
+        &self,
         graph: &str,
         label: &str,
         name: &str,
@@ -48,20 +48,20 @@ pub trait AgeClient {
     ) -> Result<u64, postgres::Error>;
 
     async fn required_constraint(
-        &mut self,
+        &self,
         graph: &str,
         label: &str,
         name: &str,
         field: &str,
     ) -> Result<u64, postgres::Error>;
 
-    async fn create_graph(&mut self, name: &str) -> Result<u64, postgres::Error>;
-    async fn drop_graph(&mut self, name: &str) -> Result<u64, postgres::Error>;
-    async fn graph_exists(&mut self, name: &str) -> Result<bool, postgres::Error>;
+    async fn create_graph(&self, name: &str) -> Result<u64, postgres::Error>;
+    async fn drop_graph(&self, name: &str) -> Result<u64, postgres::Error>;
+    async fn graph_exists(&self, name: &str) -> Result<bool, postgres::Error>;
 
-    /// Exexute cypher query, without any rows to be retured
+    /// Execute cypher query, without any rows to be retured
     async fn execute_cypher<T>(
-        &mut self,
+        &self,
         graph: &str,
         cypher: &str,
         agtype: Option<AgType<T>>,
@@ -81,7 +81,7 @@ pub trait AgeClient {
     /// MATCH (n: Person) WHERE n.name = 'Alfred' RETURN {name: n.name, surname: n.surname}
     /// ```
     async fn query_cypher<T>(
-        &mut self,
+        &self,
         graph: &str,
         cypher: &str,
         agtype: Option<AgType<T>>,
@@ -97,7 +97,7 @@ pub trait AgeClient {
     #[doc = include_str!("../examples/prepared_statements_async.rs")]
     /// ```
     async fn prepare_cypher(
-        &mut self,
+        &self,
         graph: &str,
         cypher: &str,
         use_arg: bool,
@@ -106,11 +106,11 @@ pub trait AgeClient {
 
 #[async_trait]
 impl AgeClient for Client {
-    async fn create_graph(&mut self, name: &str) -> Result<u64, postgres::Error> {
+    async fn create_graph(&self, name: &str) -> Result<u64, postgres::Error> {
         self.execute(CREATE_GRAPH, &[&name]).await
     }
 
-    async fn drop_graph(&mut self, name: &str) -> Result<u64, postgres::Error> {
+    async fn drop_graph(&self, name: &str) -> Result<u64, postgres::Error> {
         self.execute(DROP_GRAPH, &[&name]).await
     }
 
@@ -144,7 +144,7 @@ impl AgeClient for Client {
     }
 
     async fn query_cypher<T>(
-        &mut self,
+        &self,
         graph: &str,
         cypher: &str,
         agtype: Option<AgType<T>>,
@@ -170,7 +170,7 @@ impl AgeClient for Client {
     }
 
     async fn constraint(
-        &mut self,
+        &self,
         graph: &str,
         label: &str,
         name: &str,
@@ -182,7 +182,7 @@ impl AgeClient for Client {
     }
 
     async fn unique_index(
-        &mut self,
+        &self,
         graph: &str,
         label: &str,
         name: &str,
@@ -194,7 +194,7 @@ impl AgeClient for Client {
     }
 
     async fn required_constraint(
-        &mut self,
+        &self,
         graph: &str,
         label: &str,
         name: &str,
@@ -205,7 +205,7 @@ impl AgeClient for Client {
     }
 
     async fn execute_cypher<T>(
-        &mut self,
+        &self,
         graph: &str,
         cypher: &str,
         agtype: Option<AgType<T>>,
@@ -230,7 +230,7 @@ impl AgeClient for Client {
         }
     }
 
-    async fn graph_exists(&mut self, name: &str) -> Result<bool, postgres::Error> {
+    async fn graph_exists(&self, name: &str) -> Result<bool, postgres::Error> {
         match self.query(GRAPH_EXISTS, &[&name.to_string()]).await {
             Ok(result) => {
                 let x: i64 = result[0].get(0);
@@ -241,7 +241,7 @@ impl AgeClient for Client {
     }
 
     async fn prepare_cypher(
-        &mut self,
+        &self,
         graph: &str,
         cypher: &str,
         use_arg: bool,

--- a/tests/person-async.rs
+++ b/tests/person-async.rs
@@ -39,7 +39,7 @@ impl Drop for TestConnection {
 }
 
 async fn connect() -> (Client, JoinHandle<()>, String) {
-    let (mut client, join_handle) = Client::connect_age(CONN, NoTls).await.unwrap();
+    let (client, join_handle) = Client::connect_age(CONN, NoTls).await.unwrap();
 
     let graph_name = "age_test_".to_string()
         + &rand::thread_rng()
@@ -55,7 +55,7 @@ async fn connect() -> (Client, JoinHandle<()>, String) {
 
 #[tokio::test]
 async fn simple_query() {
-    let mut tc = TestConnection::new().await;
+    let tc = TestConnection::new().await;
 
     tc.client
         .simple_query(


### PR DESCRIPTION
The underlying client can work with `&self` and concurrent requests. Having if `&mut self`, will cause an issue when creating a transaction, as the transaction will borrow the client, and so it no longer is possible to mut-borrow the client.

Switching this to a simple `&self` fixes that issue.

Closes: #11 